### PR TITLE
feat: setup inicial do microsserviço de auth

### DIFF
--- a/services/auth/.env.example
+++ b/services/auth/.env.example
@@ -1,0 +1,5 @@
+AUTH_DB_HOST=db_auth
+AUTH_DB_PORT=5432
+AUTH_DB_NAME=db_autenticacao
+AUTH_DB_USER=wonder_user
+AUTH_DB_PASSWORD=

--- a/services/auth/Dockerfile
+++ b/services/auth/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8001
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]

--- a/services/auth/main.py
+++ b/services/auth/main.py
@@ -1,0 +1,34 @@
+import os
+import psycopg2
+from fastapi import FastAPI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI(
+    title="Wonder - Serviço de Autenticação",
+    description="Responsável pelo login via Google OAuth2 e geração de JWT.",
+    version="1.0.0"
+)
+
+def get_db_connection():
+    return psycopg2.connect(
+        host=os.getenv("AUTH_DB_HOST"),
+        port=os.getenv("AUTH_DB_PORT"),
+        dbname=os.getenv("AUTH_DB_NAME"),
+        user=os.getenv("AUTH_DB_USER"),
+        password=os.getenv("AUTH_DB_PASSWORD")
+    )
+
+@app.on_event("startup")
+def verificar_conexao_banco():
+    try:
+        conn = get_db_connection()
+        conn.close()
+        print("✅ Conexão com db_autenticacao estabelecida com sucesso.")
+    except Exception as e:
+        print(f"❌ Erro ao conectar com db_autenticacao: {e}")
+
+@app.get("/health", tags=["Infraestrutura"])
+def health_check():
+    return {"status": "ok", "service": "auth"}

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+psycopg2-binary==2.9.9
+python-dotenv==1.0.1


### PR DESCRIPTION
CLOSES #5 

Critérios:
[✅] services/auth/ contém: main.py, requirements.txt, Dockerfile, .env.example.
[✅] Endpoint GET /health retorna {"status": "ok", "service": "auth"}.
[✅] Serviço conecta ao banco db_autenticacao e confirma conexão no startup.
[✅] Container do auth sobe via docker compose sem erro.
[✅] Documentação automática acessível em localhost:8001/docs.