### PR TITLE
feat(ai): funcionalidade de bate-papo com IA via openrouter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     container_name: wonder_ai
     ports:
       - "8005:8005"
-    env_file: .env
+    env_file: ./services/ai/.env
     networks:
       - wonder-network
 

--- a/services/ai/requirements.txt
+++ b/services/ai/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.136.1
 uvicorn==0.46.0
 pydantic-settings==2.14.1
-google-generativeai
+openai>=1.14.0
+pydantic>=2.0.0

--- a/services/ai/src/main/core/config.py
+++ b/services/ai/src/main/core/config.py
@@ -1,7 +1,8 @@
+from typing import Optional
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
-    GEMINI_API_KEY: str
+    OPENROUTER_API_KEY: Optional[str] = None
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/services/ai/src/main/routes/ai_routes.py
+++ b/services/ai/src/main/routes/ai_routes.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, HTTPException
+from openai import OpenAI
+from src.main.core.config import settings
+from src.main.schemas.ai_schema import ChatRequest, ChatResponse
+
+router = APIRouter(tags=["Inteligência Artificial"])
+
+SYSTEM_PROMPT = (
+    "Você é o assistente virtual de inteligência do Wonder, uma plataforma de gestão "
+    "e agendamento de serviços de beleza e estética. "
+    "Você tem dois perfis de atendimento, adapte-se pela pergunta do usuário: "
+    "1. PARA CLIENTES: Ajude a escolher serviços, tire dúvidas sobre procedimentos "
+    "(cortes, coloração, tratamentos) de forma simpática e acolhedora. "
+    "2. PARA PRESTADORES: Atue como um consultor de negócios. Ajude a criar relatórios, "
+    "analisar métricas de agendamento, sugerir estratégias de marketing e gestão de salão. "
+    "Seja sempre objetivo, profissional e responda em português brasileiro. "
+    "REGRA CRÍTICA E ABSOLUTA: Você é ESTRITAMENTE PROIBIDO de responder qualquer pergunta que não seja "
+    "sobre beleza, estética, barbearia, salão ou gestão desses negócios. "
+    "Se o usuário perguntar sobre carros, mecânica, programação, culinária, política, ou qualquer outros assuntos, "
+    "você não deve dar nenhuma instrução. Responda EXATAMENTE com a seguinte frase: "
+    "'Desculpe, sou o assistente do Wonder e só posso ajudar com assuntos relacionados a beleza, estética e gestão de negócios de beleza.'"
+)
+
+def get_openrouter_client():
+    if not settings.OPENROUTER_API_KEY:
+         raise HTTPException(
+            status_code=503,
+            detail="Serviço de IA indisponível. OPENROUTER_API_KEY não configurada."
+        )
+    return OpenAI(
+        base_url="https://openrouter.ai/api/v1",
+        api_key=settings.OPENROUTER_API_KEY,
+    )
+
+@router.post("/ai/chat", response_model=ChatResponse)
+def chat(request: ChatRequest):
+
+    client = get_openrouter_client()
+
+    try:
+        response = client.chat.completions.create(
+            model="openrouter/free",
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": request.mensagem}
+            ],
+            extra_headers={
+                "HTTP-Referer": "http://localhost:8000",
+                "X-Title": "Wonder App",
+            }
+        )
+        
+        texto_resposta = response.choices[0].message.content
+        return ChatResponse(resposta=texto_resposta)
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Erro ao processar resposta do OpenRouter: {str(e)}"
+        )

--- a/services/ai/src/main/schemas/ai_schema.py
+++ b/services/ai/src/main/schemas/ai_schema.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class ChatRequest(BaseModel):
+    mensagem: str
+
+class ChatResponse(BaseModel):
+    resposta: str

--- a/services/ai/src/main/server/app.py
+++ b/services/ai/src/main/server/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from src.main.core.config import settings
+from src.main.routes.ai_routes import router as ai_router
 
 app = FastAPI(
     title="Wonder - Serviço AI",
@@ -9,10 +10,12 @@ app = FastAPI(
 
 @app.on_event("startup")
 def verificar_configuracao():
-    if settings.GEMINI_API_KEY:
-        print("✅ GEMINI_API_KEY carregada com sucesso via Pydantic.")
+    if settings.OPENROUTER_API_KEY:
+        print("✅ OPENROUTER_API_KEY carregada com sucesso.", flush=True)
     else:
-        print("⚠️  GEMINI_API_KEY não encontrada no .env.")
+        print("⚠️  OPENROUTER_API_KEY não encontrada. Endpoint /ai/chat retornará 503.", flush=True)
+
+app.include_router(ai_router)
 
 @app.get("/health", tags=["Infraestrutura"])
 def health_check():


### PR DESCRIPTION
Close #35 

- Implementação do serviço de Inteligência Artificial para atender clientes e prestadores.
- Usando OpenRouter (openrouter/free) para buscar LLM gratuito e não quebrar o serviço.
- Adicionado atendimento simpático pro cliente final vs. dicas de negócio/métricas pro prestador.
- Regra estrita no prompt para bloquear qualquer prompt injection ou perguntas fora de contexto, evitando alucinação.
- Tratamento de API Key ausente (503) e falha de comunicação com a IA (500).