### PR TITLE
feat(agendamentos): publica evento ao cancelar agendamento

### DIFF
--- a/services/agendamentos/src/main/repositories/agendamento_repo.py
+++ b/services/agendamentos/src/main/repositories/agendamento_repo.py
@@ -42,6 +42,37 @@ def publicar_evento(agendamento: Agendamento):
         print(f"⚠️  Falha ao publicar no RabbitMQ: {e}")
 
 
+def publicar_evento_cancelamento(agendamento: Agendamento, motivo: str = None):
+    """Publica o evento de cancelamento sem impedir a atualização no banco."""
+    try:
+        credentials = pika.PlainCredentials(settings.RABBITMQ_USER, settings.RABBITMQ_PASSWORD)
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=settings.RABBITMQ_HOST,
+                port=settings.RABBITMQ_PORT,
+                credentials=credentials
+            )
+        )
+        channel = connection.channel()
+        channel.queue_declare(queue=settings.RABBITMQ_QUEUE, durable=True)
+        channel.basic_publish(
+            exchange="",
+            routing_key=settings.RABBITMQ_QUEUE,
+            body=json.dumps({
+                "agendamento_id": agendamento.id,
+                "cliente_id": agendamento.cliente_id,
+                "prestador_id": agendamento.prestador_id,
+                "status_novo": "cancelado",
+                "motivo": motivo
+            }),
+            properties=pika.BasicProperties(delivery_mode=2)
+        )
+        connection.close()
+        print(f"✅ Evento de cancelamento publicado para agendamento id={agendamento.id}")
+    except Exception as e:
+        print(f"⚠️  Falha ao publicar cancelamento no RabbitMQ: {e}")
+
+
 def listar_agendamentos(db: Session, cliente_id: int) -> list[Agendamento]:
     return db.query(Agendamento).filter(Agendamento.cliente_id == cliente_id).all()
 
@@ -144,5 +175,8 @@ def atualizar_status(
     db.add(historico)
     db.commit()
     db.refresh(agendamento)
+
+    if dados.status == "cancelado":
+        publicar_evento_cancelamento(agendamento, motivo=dados.motivo)
 
     return agendamento

--- a/services/notificacao/src/main/consumer/consumer.py
+++ b/services/notificacao/src/main/consumer/consumer.py
@@ -19,12 +19,14 @@ def processar_mensagem(ch, method, properties, body):
 
         cliente_id  = int(dados.get("cliente_id"))
         agendamento_id = dados.get("agendamento_id")
-        inicio      = dados.get("inicio", "horário não informado")
-
-        mensagem = (
-            f"Seu agendamento #{agendamento_id} foi confirmado para {inicio}. "
-            f"Até breve!"
-        )
+        if dados.get("status_novo") == "cancelado":
+            mensagem = f"Seu agendamento #{agendamento_id} foi cancelado."
+        else:
+            inicio = dados.get("inicio", "horário não informado")
+            mensagem = (
+                f"Seu agendamento #{agendamento_id} foi confirmado para {inicio}. "
+                f"Até breve!"
+            )
 
         db = SessionLocal()
         try:
@@ -64,12 +66,12 @@ def iniciar_consumer():
             channel = connection.channel()
 
             # Garante que a fila existe antes de escutar
-            channel.queue_declare(queue="wonder.eventos", durable=True)
+            channel.queue_declare(queue=settings.RABBITMQ_QUEUE, durable=True)
 
             # Processa uma mensagem por vez
             channel.basic_qos(prefetch_count=1)
             channel.basic_consume(
-                queue="wonder.eventos",
+                queue=settings.RABBITMQ_QUEUE,
                 on_message_callback=processar_mensagem
             )
 


### PR DESCRIPTION
## Descrição

- Adicionada publicação de evento RabbitMQ ao cancelar um agendamento.
- O evento é publicado somente após a atualização ser persistida no banco.
- A mensagem contém `agendamento_id`, `cliente_id`, `prestador_id`, `status_novo` e `motivo`.
- Falhas na publicação são registradas sem impedir o cancelamento do agendamento.
- Atualizado o consumer de notificações para criar uma notificação quando receber um evento de cancelamento.

Close #50 