### PR TITLE
feat(catalogo): adiciona filtros de prestadores e lista categorias

### DIFF
--- a/services/catalogo/src/main/repositories/prestador_repo.py
+++ b/services/catalogo/src/main/repositories/prestador_repo.py
@@ -5,8 +5,13 @@ from src.main.schemas.prestador_schema import AvaliacaoCreate, HorarioCreate, Pr
 
 # LEITURA
 
-def listar_ativos(db: Session):
-    return db.query(Prestador).filter(Prestador.status == "ativo").order_by(Prestador.nome_estab).all()
+def listar_ativos(db: Session, nome: str = None, categoria_id: int = None):
+    query = db.query(Prestador).filter(Prestador.status == "ativo")
+    if nome:
+        query = query.filter(Prestador.nome_estab.ilike(f"%{nome}%"))
+    if categoria_id:
+        query = query.join(Servico).filter(Servico.categoria_id == categoria_id)
+    return query.order_by(Prestador.nome_estab).all()
 
 def obter_por_id(db: Session, prestador_id: int):
     return db.query(Prestador).filter(Prestador.id == prestador_id).first()

--- a/services/catalogo/src/main/routes/prestador_routes.py
+++ b/services/catalogo/src/main/routes/prestador_routes.py
@@ -3,9 +3,10 @@ from sqlalchemy.orm import Session
 from typing import List
 
 from src.main.dependencies.db import get_db
+from src.main.models.prestador_model import Categoria
 from src.main.repositories import prestador_repo
 from src.main.schemas.prestador_schema import (
-    AvaliacaoCreate, AvaliacaoResponse, HorarioCreate, HorarioResponse,
+    AvaliacaoCreate, AvaliacaoResponse, CategoriaResponse, HorarioCreate, HorarioResponse,
     PrestadorCreate, PrestadorUpdate, PrestadorResponse, ServicoCreate, ServicoResponse
 )
 
@@ -20,8 +21,13 @@ def is_admin(request: Request) -> bool:
 # LEITURA
 
 @router.get("/prestadores", response_model=List[PrestadorResponse])
-def listar_prestadores(request: Request, db: Session = Depends(get_db)):
-    prestadores = prestador_repo.listar_ativos(db)
+def listar_prestadores(
+    request: Request,
+    nome: str = None,
+    categoria_id: int = None,
+    db: Session = Depends(get_db)
+):
+    prestadores = prestador_repo.listar_ativos(db, nome=nome, categoria_id=categoria_id)
     
     if is_admin(request):
         prestador_repo.registrar_auditoria(
@@ -29,6 +35,10 @@ def listar_prestadores(request: Request, db: Session = Depends(get_db)):
         )
         
     return prestadores
+
+@router.get("/categorias", response_model=List[CategoriaResponse])
+def listar_categorias(db: Session = Depends(get_db)):
+    return db.query(Categoria).all()
 
 @router.get("/prestadores/{prestador_id}", response_model=PrestadorResponse)
 def obter_prestador(prestador_id: int, request: Request, db: Session = Depends(get_db)):

--- a/services/catalogo/src/main/schemas/prestador_schema.py
+++ b/services/catalogo/src/main/schemas/prestador_schema.py
@@ -20,6 +20,13 @@ class ServicoResponse(ServicoBase):
     class Config:
         from_attributes = True
 
+class CategoriaResponse(BaseModel):
+    id: int
+    nome: str
+
+    class Config:
+        from_attributes = True
+
 # SCHEMAS DE PRESTADOR
 
 class PrestadorBase(BaseModel):


### PR DESCRIPTION
## Descrição

- Adicionados filtros `nome` e `categoria_id` ao endpoint `GET /catalogo/prestadores`.
- O filtro por nome permite busca parcial e case-insensitive.
- O filtro por categoria filtra prestadores vinculados a serviços da categoria informada.
- Criado o endpoint `GET /catalogo/categorias`.
- Adicionado `CategoriaResponse` com `id` e `nome` como `response_model` da rota de categorias.