### PR TITLE
feat(notificacao): adiciona leitura e filtro de notificacoes

### DIFF
--- a/gateway/src/main/server/app.py
+++ b/gateway/src/main/server/app.py
@@ -6,6 +6,10 @@ from src.main.core.config import settings
 
 PUBLIC_PREFIXES = ["/auth/", "/health"]
 
+SERVICE_PREFIX_ALIASES = {
+    "notificacoes": "notificacao",
+}
+
 app = FastAPI(
     title="Wonder - API Gateway",
     description="Ponto de entrada único para todos os microsserviços.",
@@ -31,6 +35,11 @@ def resolve_service(path: str):
     for name, url in settings.services.items():
         if path.startswith(f"/{name}"):
             return name, url
+
+    for prefix, service_name in SERVICE_PREFIX_ALIASES.items():
+        if path.startswith(f"/{prefix}"):
+            return service_name, settings.services[service_name]
+
     return None, None
 
 @app.get("/health", tags=["Infraestrutura"])

--- a/services/notificacao/src/main/repositories/notificacao_repo.py
+++ b/services/notificacao/src/main/repositories/notificacao_repo.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from fastapi import HTTPException
 from src.main.models.notificacao_model import Notificacao
 
 def criar(db: Session, usuario_id: int, mensagem: str):
@@ -10,3 +11,25 @@ def criar(db: Session, usuario_id: int, mensagem: str):
     db.commit()
     db.refresh(nova_notificacao)
     return nova_notificacao
+
+def listar_notificacoes(db: Session, usuario_id: int, status: str = None):
+    query = db.query(Notificacao).filter(Notificacao.usuario_id == usuario_id)
+
+    if status:
+        query = query.filter(Notificacao.status == status)
+
+    return query.all()
+
+def marcar_como_lida(db: Session, notificacao_id: int, usuario_id: int):
+    notificacao = db.query(Notificacao).filter(
+        Notificacao.id == notificacao_id,
+        Notificacao.usuario_id == usuario_id
+    ).first()
+
+    if not notificacao:
+        raise HTTPException(status_code=404, detail="Notificação não encontrada.")
+
+    notificacao.status = "lida"
+    db.commit()
+    db.refresh(notificacao)
+    return notificacao

--- a/services/notificacao/src/main/routes/notificacao_routes.py
+++ b/services/notificacao/src/main/routes/notificacao_routes.py
@@ -1,16 +1,29 @@
 from typing import List
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 from src.main.dependencies.db import get_db
-from src.main.models.notificacao_model import Notificacao
+from src.main.repositories import notificacao_repo
 from src.main.schemas.notificacao_schema import NotificacaoResponse
 
 router = APIRouter(tags=["Notificações"])
 
+def get_user_id(request: Request) -> int:
+    return int(request.headers.get("X-User-ID"))
+
 @router.get("/notificacoes", response_model=List[NotificacaoResponse])
 def listar_notificacoes(
-    x_user_id: int = Header(..., alias="X-User-ID"),
+    request: Request,
+    status: str = None,
     db: Session = Depends(get_db)
 ):
-    notificacoes = db.query(Notificacao).filter(Notificacao.usuario_id == x_user_id).all()
-    return notificacoes
+    usuario_id = get_user_id(request)
+    return notificacao_repo.listar_notificacoes(db, usuario_id, status=status)
+
+@router.patch("/notificacoes/{id}/lida", response_model=NotificacaoResponse)
+def marcar_notificacao_como_lida(
+    id: int,
+    request: Request,
+    db: Session = Depends(get_db)
+):
+    usuario_id = get_user_id(request)
+    return notificacao_repo.marcar_como_lida(db, id, usuario_id)


### PR DESCRIPTION
## Descrição

- Adicionado filtro `status` no endpoint `GET /notificacoes`.
- Criado endpoint `PATCH /notificacoes/{id}/lida` para marcar notificação como lida.
- Movida a lógica de listagem e atualização para `notificacao_repo.py`.
- Ajustado o Gateway para rotear `/notificacoes` para o serviço de Notificação.
- Mantido o repasse dos headers `Authorization`, `X-User-ID` e `X-User-Role`.

## Endpoints adicionados/ajustados

- `GET /notificacoes`
- `GET /notificacoes?status=pendente`
- `GET /notificacoes?status=lida`
- `PATCH /notificacoes/{id}/lida`