### PR TITLE
feat(auth): adiciona gerenciamento admin de usuarios

### DIFF
--- a/gateway/src/main/server/app.py
+++ b/gateway/src/main/server/app.py
@@ -4,7 +4,7 @@ from fastapi.responses import Response
 from jose import jwt, JWTError, ExpiredSignatureError
 from src.main.core.config import settings
 
-PUBLIC_PREFIXES = ["/auth/", "/health"]
+PUBLIC_PREFIXES = ["/auth/google/", "/health"]
 
 SERVICE_PREFIX_ALIASES = {
     "notificacoes": "notificacao",

--- a/services/auth/src/main/repositories/user_repo.py
+++ b/services/auth/src/main/repositories/user_repo.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql import func
+from fastapi import HTTPException
 from src.main.models.user_model import CustomUser
 
 def upsert_usuario(db: Session, email: str, username: str) -> CustomUser:
@@ -19,3 +20,21 @@ def upsert_usuario(db: Session, email: str, username: str) -> CustomUser:
     db.commit()
     
     return result.scalar_one()
+
+def listar_usuarios(db: Session):
+    return db.query(CustomUser).all()
+
+def obter_usuario(db: Session, user_id: int):
+    user = db.query(CustomUser).filter(CustomUser.id == user_id).first()
+
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuário não encontrado.")
+
+    return user
+
+def atualizar_tipo(db: Session, user_id: int, novo_tipo: str):
+    user = obter_usuario(db, user_id)
+    user.tipo_usuario = novo_tipo
+    db.commit()
+    db.refresh(user)
+    return user

--- a/services/auth/src/main/routes/auth_routes.py
+++ b/services/auth/src/main/routes/auth_routes.py
@@ -1,5 +1,6 @@
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -7,13 +8,20 @@ from src.main.core.config import settings
 from src.main.dependencies.db import get_db
 from src.main.repositories import user_repo
 from src.main.core.security import gerar_jwt
-from src.main.schemas.auth_schema import TokenResponse
+from src.main.schemas.auth_schema import TipoUpdate, TokenResponse, UsuarioResponse
 
 router = APIRouter(tags=["Autenticação"])
 
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_USER_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+def is_admin(request: Request) -> bool:
+    return request.headers.get("X-User-Role", "").lower() == "admin"
+
+def validar_admin(request: Request):
+    if not is_admin(request):
+        raise HTTPException(status_code=403, detail="Acesso restrito a administradores.")
 
 @router.get("/auth/google/login")
 def google_login():
@@ -70,3 +78,22 @@ async def google_callback(code: str, db: Session = Depends(get_db)):
             "tipo_usuario": usuario.tipo_usuario
         }
     }
+
+@router.get("/auth/usuarios", response_model=List[UsuarioResponse])
+def listar_usuarios(request: Request, db: Session = Depends(get_db)):
+    validar_admin(request)
+    return user_repo.listar_usuarios(db)
+
+@router.get("/auth/usuarios/{user_id}", response_model=UsuarioResponse)
+def obter_usuario(user_id: int, request: Request, db: Session = Depends(get_db)):
+    validar_admin(request)
+    return user_repo.obter_usuario(db, user_id)
+
+@router.patch("/auth/usuarios/{user_id}/tipo", response_model=UsuarioResponse)
+def atualizar_tipo(user_id: int, dados: TipoUpdate, request: Request, db: Session = Depends(get_db)):
+    validar_admin(request)
+
+    if dados.tipo_usuario not in ["cliente", "prestador", "admin"]:
+        raise HTTPException(status_code=400, detail="Tipo inválido.")
+
+    return user_repo.atualizar_tipo(db, user_id, dados.tipo_usuario)

--- a/services/auth/src/main/schemas/auth_schema.py
+++ b/services/auth/src/main/schemas/auth_schema.py
@@ -8,6 +8,9 @@ class UsuarioResponse(BaseModel):
     class Config:
         from_attributes = True
 
+class TipoUpdate(BaseModel):
+    tipo_usuario: str
+
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"


### PR DESCRIPTION
## Descrição

- Criados endpoints administrativos para gerenciamento de usuários no serviço Auth.
- Adicionado `GET /auth/usuarios` para listar usuários.
- Adicionado `GET /auth/usuarios/{id}` para buscar usuário por ID.
- Adicionado `PATCH /auth/usuarios/{id}/tipo` para atualizar o tipo do usuário.
- Adicionados schemas `UsuarioResponse` e `TipoUpdate`.
- Adicionadas funções de repositório para listar, buscar e atualizar usuários.
- Protegidos os endpoints por `X-User-Role: admin`.
- Ajustado o Gateway para manter público apenas `/auth/google/*`, garantindo que `/auth/usuarios/*` exija JWT e receba os headers `X-User-ID` e `X-User-Role`.
