### PR TITLE
feat(admin): implementa endpoint unificado de relatorios de auditoria

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - agendamentos
       - notificacao
       - ai
+      - admin
     networks:
       - wonder-network
 
@@ -75,6 +76,24 @@ services:
     ports:
       - "8005:8005"
     env_file: ./services/ai/.env
+    networks:
+      - wonder-network
+
+  admin:
+    build: ./services/admin
+    container_name: wonder_admin
+    ports:
+      - "8006:8006"
+    env_file: .env
+    depends_on:
+      db_auth:
+        condition: service_healthy
+      db_catalogo:
+        condition: service_healthy
+      db_agendamentos:
+        condition: service_healthy
+      db_notificacoes:
+        condition: service_healthy
     networks:
       - wonder-network
 

--- a/gateway/src/main/core/config.py
+++ b/gateway/src/main/core/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     AGENDAMENTOS_SERVICE_URL: str = "http://agendamentos:8003"
     NOTIFICACAO_SERVICE_URL: str = "http://notificacao:8004"
     AI_SERVICE_URL: str = "http://ai:8005"
+    ADMIN_SERVICE_URL: str = "http://admin:8006"
 
     @property
     def services(self) -> Dict[str, str]:
@@ -19,6 +20,7 @@ class Settings(BaseSettings):
             "agendamentos": self.AGENDAMENTOS_SERVICE_URL,
             "notificacao": self.NOTIFICACAO_SERVICE_URL,
             "ai": self.AI_SERVICE_URL,
+            "admin": self.ADMIN_SERVICE_URL,
         }
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/services/admin/.env.example
+++ b/services/admin/.env.example
@@ -1,0 +1,34 @@
+# O serviço admin não tem banco próprio: ele se conecta em modo leitura
+# nos quatro bancos para agregar os logs de auditoria (tabela logs_auditoria,
+# já criada pelos triggers PL/pgSQL de cada serviço).
+#
+# Em docker-compose, estas variáveis já vêm do .env raiz (env_file: .env).
+# Este arquivo serve apenas para referência/execução standalone do serviço.
+
+# Banco de dados - Auth
+AUTH_DB_HOST=db_auth
+AUTH_DB_PORT=5432
+AUTH_DB_NAME=db_autenticacao
+AUTH_DB_USER=wonder_user
+AUTH_DB_PASSWORD=
+
+# Banco de dados - Catálogo
+CATALOGO_DB_HOST=db_catalogo
+CATALOGO_DB_PORT=5432
+CATALOGO_DB_NAME=db_catalogo
+CATALOGO_DB_USER=wonder_user
+CATALOGO_DB_PASSWORD=
+
+# Banco de dados - Agendamentos
+AGENDAMENTOS_DB_HOST=db_agendamentos
+AGENDAMENTOS_DB_PORT=5432
+AGENDAMENTOS_DB_NAME=db_agendamentos
+AGENDAMENTOS_DB_USER=wonder_user
+AGENDAMENTOS_DB_PASSWORD=
+
+# Banco de dados - Notificações
+NOTIFICACOES_DB_HOST=db_notificacoes
+NOTIFICACOES_DB_PORT=5432
+NOTIFICACOES_DB_NAME=db_notificacoes
+NOTIFICACOES_DB_USER=wonder_user
+NOTIFICACOES_DB_PASSWORD=

--- a/services/admin/Dockerfile
+++ b/services/admin/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8006
+
+CMD ["uvicorn", "src.main.server.app:app", "--host", "0.0.0.0", "--port", "8006"]

--- a/services/admin/requirements.txt
+++ b/services/admin/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.136.1
+uvicorn==0.46.0
+SQLAlchemy==2.0.49
+psycopg2-binary==2.9.12
+pydantic-settings==2.14.1

--- a/services/admin/src/main/core/config.py
+++ b/services/admin/src/main/core/config.py
@@ -1,0 +1,50 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    AUTH_DB_HOST: str
+    AUTH_DB_PORT: str
+    AUTH_DB_NAME: str
+    AUTH_DB_USER: str
+    AUTH_DB_PASSWORD: str
+
+    CATALOGO_DB_HOST: str
+    CATALOGO_DB_PORT: str
+    CATALOGO_DB_NAME: str
+    CATALOGO_DB_USER: str
+    CATALOGO_DB_PASSWORD: str
+
+    AGENDAMENTOS_DB_HOST: str
+    AGENDAMENTOS_DB_PORT: str
+    AGENDAMENTOS_DB_NAME: str
+    AGENDAMENTOS_DB_USER: str
+    AGENDAMENTOS_DB_PASSWORD: str
+
+    NOTIFICACOES_DB_HOST: str
+    NOTIFICACOES_DB_PORT: str
+    NOTIFICACOES_DB_NAME: str
+    NOTIFICACOES_DB_USER: str
+    NOTIFICACOES_DB_PASSWORD: str
+
+    def _url(self, prefix: str) -> str:
+        host = getattr(self, f"{prefix}_DB_HOST")
+        port = getattr(self, f"{prefix}_DB_PORT")
+        name = getattr(self, f"{prefix}_DB_NAME")
+        user = getattr(self, f"{prefix}_DB_USER")
+        password = getattr(self, f"{prefix}_DB_PASSWORD")
+        return f"postgresql://{user}:{password}@{host}:{port}/{name}"
+
+    @property
+    def database_urls(self) -> dict:
+        # As chaves correspondem aos valores aceitos pelo query param ?banco=
+        return {
+            "auth": self._url("AUTH"),
+            "catalogo": self._url("CATALOGO"),
+            "agendamentos": self._url("AGENDAMENTOS"),
+            "notificacoes": self._url("NOTIFICACOES"),
+        }
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+settings = Settings()

--- a/services/admin/src/main/core/database.py
+++ b/services/admin/src/main/core/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from src.main.core.config import settings
+
+# Um engine por banco — o admin não possui banco próprio, apenas lê
+# a tabela logs_auditoria já existente em cada um dos quatro bancos.
+engines = {
+    nome: create_engine(url, pool_pre_ping=True)
+    for nome, url in settings.database_urls.items()
+}

--- a/services/admin/src/main/dependencies/auth.py
+++ b/services/admin/src/main/dependencies/auth.py
@@ -1,0 +1,8 @@
+from fastapi import HTTPException, Request
+
+
+def exigir_admin(request: Request) -> None:
+    """Bloqueia o acesso caso o header X-User-Role (injetado pelo Gateway
+    a partir do JWT) não seja 'admin'."""
+    if request.headers.get("X-User-Role", "").lower() != "admin":
+        raise HTTPException(status_code=403, detail="Acesso restrito a administradores.")

--- a/services/admin/src/main/repositories/auditoria_repo.py
+++ b/services/admin/src/main/repositories/auditoria_repo.py
@@ -1,0 +1,64 @@
+from typing import List, Optional
+from sqlalchemy import text
+from src.main.core.database import engines
+
+BANCOS_VALIDOS = list(engines.keys())  # auth, catalogo, agendamentos, notificacoes
+
+
+def _query_banco(nome_banco: str, operacao: Optional[str], tabela: Optional[str], limit: int) -> List[dict]:
+    engine = engines[nome_banco]
+
+    sql = (
+        "SELECT id, usuario_id, operacao, tabela_afetada, dados_antigos, dados_novos, data_hora "
+        "FROM logs_auditoria WHERE 1=1"
+    )
+    params: dict = {}
+
+    if operacao:
+        sql += " AND operacao = :operacao"
+        params["operacao"] = operacao
+    if tabela:
+        sql += " AND tabela_afetada = :tabela"
+        params["tabela"] = tabela
+
+    sql += " ORDER BY data_hora DESC LIMIT :limit"
+    params["limit"] = limit
+
+    with engine.connect() as conn:
+        rows = conn.execute(text(sql), params).mappings().all()
+
+    resultado = []
+    for row in rows:
+        item = dict(row)
+        item["id"] = str(item["id"])
+        item["banco"] = nome_banco
+        resultado.append(item)
+    return resultado
+
+
+def buscar_logs(
+    banco: Optional[str], operacao: Optional[str], tabela: Optional[str], limit: int
+) -> List[dict]:
+    bancos = [banco] if banco else BANCOS_VALIDOS
+
+    resultados: List[dict] = []
+    for nome_banco in bancos:
+        resultados.extend(_query_banco(nome_banco, operacao, tabela, limit))
+
+    # Ao consultar múltiplos bancos, cada um já vem ordenado e limitado
+    # individualmente — aqui reordenamos o conjunto agregado e aplicamos
+    # o limite final, do mais recente para o mais antigo.
+    resultados.sort(key=lambda item: item["data_hora"], reverse=True)
+    return resultados[:limit]
+
+
+def resumo_auditoria() -> List[dict]:
+    sql = "SELECT operacao, COUNT(*) AS total FROM logs_auditoria GROUP BY operacao ORDER BY operacao"
+
+    resultados: List[dict] = []
+    for nome_banco, engine in engines.items():
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql)).mappings().all()
+        for row in rows:
+            resultados.append({"banco": nome_banco, "operacao": row["operacao"], "total": row["total"]})
+    return resultados

--- a/services/admin/src/main/routes/auditoria_routes.py
+++ b/services/admin/src/main/routes/auditoria_routes.py
@@ -1,0 +1,40 @@
+from typing import List, Optional
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.main.dependencies.auth import exigir_admin
+from src.main.repositories import auditoria_repo
+from src.main.schemas.auditoria_schema import LogAuditoriaResponse, ResumoAuditoriaItem
+
+router = APIRouter(tags=["Admin"], dependencies=[Depends(exigir_admin)])
+
+BANCOS_VALIDOS = ["auth", "catalogo", "agendamentos", "notificacoes"]
+OPERACOES_VALIDAS = ["INSERT", "UPDATE", "DELETE", "SELECT"]
+
+
+@router.get("/auditoria", response_model=List[LogAuditoriaResponse])
+def listar_auditoria(
+    banco: Optional[str] = Query(None, description="auth | catalogo | agendamentos | notificacoes"),
+    operacao: Optional[str] = Query(None, description="INSERT | UPDATE | DELETE | SELECT"),
+    tabela: Optional[str] = Query(None, description="Nome da tabela afetada"),
+    limit: int = Query(50, ge=1, le=500),
+):
+    if banco and banco not in BANCOS_VALIDOS:
+        raise HTTPException(
+            status_code=400, detail=f"Banco inválido. Use um de: {', '.join(BANCOS_VALIDOS)}"
+        )
+    if operacao and operacao.upper() not in OPERACOES_VALIDAS:
+        raise HTTPException(
+            status_code=400, detail=f"Operação inválida. Use uma de: {', '.join(OPERACOES_VALIDAS)}"
+        )
+
+    return auditoria_repo.buscar_logs(
+        banco=banco,
+        operacao=operacao.upper() if operacao else None,
+        tabela=tabela,
+        limit=limit,
+    )
+
+
+@router.get("/auditoria/resumo", response_model=List[ResumoAuditoriaItem])
+def resumo_auditoria():
+    return auditoria_repo.resumo_auditoria()

--- a/services/admin/src/main/schemas/auditoria_schema.py
+++ b/services/admin/src/main/schemas/auditoria_schema.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class LogAuditoriaResponse(BaseModel):
+    id: str
+    banco: str
+    usuario_id: Optional[int] = None
+    operacao: str
+    tabela_afetada: str
+    dados_antigos: Optional[dict] = None
+    dados_novos: Optional[dict] = None
+    data_hora: datetime
+
+
+class ResumoAuditoriaItem(BaseModel):
+    banco: str
+    operacao: str
+    total: int

--- a/services/admin/src/main/server/app.py
+++ b/services/admin/src/main/server/app.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from src.main.routes import auditoria_routes
+
+app = FastAPI(
+    title="Wonder - Serviço Admin",
+    description="Serviço administrativo: consulta unificada dos logs de auditoria dos quatro bancos.",
+    version="1.0.0"
+)
+
+app.include_router(auditoria_routes.router, prefix="/admin")
+
+@app.get("/health", tags=["Infraestrutura"])
+def health_check():
+    return {"status": "ok", "service": "admin"}


### PR DESCRIPTION
* Criado o serviço `services/admin/`, seguindo a mesma estrutura dos demais serviços (core, dependencies, repositories, routes, schemas, server).
* Implementado o endpoint `GET /admin/auditoria`, consultando os logs de auditoria dos quatro bancos (auth, catalogo, agendamentos, notificacoes) de forma unificada.
* Suporte a filtros opcionais via query string: `?banco=`, `?operacao=`, `?tabela=` e `?limit=` (padrão 50).
* Implementado o endpoint `GET /admin/auditoria/resumo`, retornando contagem de operações agrupadas por banco e tipo.
* Acesso protegido via header `X-User-Role: admin`, seguindo o mesmo padrão já usado no serviço de Catálogo.
* Requisições sem role admin retornam `403`.
* Parâmetros `banco` ou `operacao` inválidos retornam `400` antes de qualquer consulta ao banco.
* O serviço admin não possui banco próprio — apenas lê a tabela `logs_auditoria` já existente nos quatro bancos.
* Adicionado `ADMIN_SERVICE_URL` na configuração do Gateway, com roteamento `/admin/*`.
* Serviço adicionado ao `docker-compose.yml` (porta 8006), com `depends_on` dos quatro bancos.