### PR TITLE
feat(infra): implementa scripts de manutenção automatizada do PostgreSQL

### DIFF
--- a/docs/MANUTENCAO.md
+++ b/docs/MANUTENCAO.md
@@ -1,0 +1,93 @@
+# Manutenção do PostgreSQL — Wonder App
+
+Este documento descreve os scripts de manutenção automatizada dos quatro
+bancos PostgreSQL do sistema (`db_autenticacao`, `db_catalogo`,
+`db_agendamentos`, `db_notificacoes`).
+
+## Scripts disponíveis
+
+### `scripts/maintenance.sh`
+
+O que faz: executa `VACUUM ANALYZE` e `REINDEX TABLE` nas tabelas
+principais dos quatro bancos.
+
+- `VACUUM ANALYZE` recupera o espaço ocupado por linhas mortas (deixadas
+  por UPDATE/DELETE) e atualiza as estatísticas usadas pelo otimizador de
+  consultas do PostgreSQL.
+- `REINDEX TABLE` reconstrói os índices das tabelas, evitando que fiquem
+  fragmentados/inchados ao longo do tempo.
+
+Tabelas cobertas por banco:
+
+| Banco             | Tabelas                                                                 |
+|--------------------|--------------------------------------------------------------------------|
+| db_autenticacao    | customuser, logs_auditoria                                              |
+| db_catalogo        | categoria, prestador, servico, horariofuncionamento, fotoestabelecimento, avaliacao, logs_auditoria |
+| db_agendamentos    | agendamento, historico_agendamento, logs_auditoria                      |
+| db_notificacoes    | notificacao, logs_auditoria                                             |
+
+> Nota: os nomes das tabelas são em minúsculas propositalmente — o
+> PostgreSQL guarda identificadores sem aspas sempre em minúsculas, e é
+> assim que elas foram criadas em `sql/*.sql` e mapeadas no ORM
+> (`__tablename__`).
+
+### `scripts/cleanup_logs.sh`
+
+O que faz: remove da tabela `logs_auditoria` (presente nos quatro bancos)
+os registros com `data_hora` anterior a 90 dias, evitando que a tabela de
+auditoria cresça indefinidamente.
+
+O período de retenção é configurável via variável de ambiente
+`DIAS_RETENCAO` (padrão: 90).
+
+## Quando executar
+
+- **`maintenance.sh`**: recomenda-se rodar semanalmente, ou após grandes
+  volumes de INSERT/UPDATE/DELETE (ex: testes de carga, importações).
+- **`cleanup_logs.sh`**: recomenda-se rodar mensalmente, para manter a
+  tabela de auditoria com tamanho controlado.
+
+Ambos podem ser agendados via `cron` no mesmo container.
+
+## Como executar
+
+Pré-requisito: os containers dos bancos precisam estar em execução
+(`docker compose up -d db_auth db_catalogo db_agendamentos db_notificacoes`).
+
+```bash
+# Dar permissão de execução (uma vez só, ou no Git Bash / WSL no Windows)
+chmod +x scripts/maintenance.sh scripts/cleanup_logs.sh
+
+# Rodar a manutenção (VACUUM ANALYZE + REINDEX)
+./scripts/maintenance.sh
+
+# Rodar a limpeza de logs antigos
+./scripts/cleanup_logs.sh
+```
+
+Ambos os scripts imprimem no terminal qual banco e qual operação estão
+sendo executados a cada passo, e finalizam com um resumo de início/fim.
+
+### Alternativa: executar direto via `docker compose exec`
+
+Caso prefira rodar comandos avulsos sem os scripts, por exemplo direto no
+Postgres do catálogo:
+
+```bash
+docker compose exec db_catalogo psql -U wonder_user -d db_catalogo -c "VACUUM ANALYZE prestador;"
+```
+
+## Exemplo de saída esperada
+
+```
+=== Wonder App — Manutenção do PostgreSQL (VACUUM ANALYZE + REINDEX) ===
+Iniciado em: 2026-07-03 15:20:00
+
+--- Banco: db_autenticacao (serviço: db_auth) ---
+[db_autenticacao] VACUUM ANALYZE customuser...
+VACUUM
+[db_autenticacao] REINDEX TABLE customuser...
+REINDEX
+...
+=== Manutenção finalizada em: 2026-07-03 15:20:12 ===
+```

--- a/scripts/cleanup_logs.sh
+++ b/scripts/cleanup_logs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# scripts/cleanup_logs.sh
+#
+# Remove registros da tabela logs_auditoria com mais de 90 dias em cada
+# um dos quatro bancos PostgreSQL do Wonder App (Issue 25).
+#
+# Uso:
+#   ./scripts/cleanup_logs.sh
+#
+# Pré-requisito: os containers dos bancos precisam estar rodando.
+#
+set -euo pipefail
+
+# service_docker_compose | nome_do_banco
+DATABASES=(
+  "db_auth|db_autenticacao"
+  "db_catalogo|db_catalogo"
+  "db_agendamentos|db_agendamentos"
+  "db_notificacoes|db_notificacoes"
+)
+
+DB_USER="${DB_USER:-wonder_user}"
+DIAS_RETENCAO="${DIAS_RETENCAO:-90}"
+
+echo "=== Wonder App — Limpeza de logs_auditoria (mais de ${DIAS_RETENCAO} dias) ==="
+echo "Iniciado em: $(date '+%Y-%m-%d %H:%M:%S')"
+echo
+
+for entry in "${DATABASES[@]}"; do
+  IFS='|' read -r servico banco <<< "$entry"
+
+  echo "--- Banco: ${banco} (serviço: ${servico}) ---"
+  echo "[${banco}] Removendo registros de logs_auditoria anteriores a ${DIAS_RETENCAO} dias..."
+
+  docker compose exec -T "${servico}" psql -U "${DB_USER}" -d "${banco}" \
+    -c "DELETE FROM logs_auditoria WHERE data_hora < NOW() - INTERVAL '${DIAS_RETENCAO} days';"
+
+  echo "[${banco}] Concluído."
+  echo
+done
+
+echo "=== Limpeza finalizada em: $(date '+%Y-%m-%d %H:%M:%S') ==="

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# scripts/maintenance.sh
+#
+# Executa VACUUM ANALYZE e REINDEX nas tabelas principais dos quatro
+# bancos PostgreSQL do Wonder App (Issue 25).
+#
+# Uso:
+#   ./scripts/maintenance.sh
+#
+# Pré-requisito: os containers dos bancos precisam estar rodando
+# (docker compose up -d db_auth db_catalogo db_agendamentos db_notificacoes)
+#
+set -euo pipefail
+
+# service_docker_compose | nome_do_banco | tabelas (separadas por espaço)
+#
+# Nomes em minúsculas propositalmente: o PostgreSQL guarda identificadores
+# não citados (sem aspas) sempre em minúsculas, e é assim que as tabelas
+# foram criadas nos scripts sql/*.sql e mapeadas no ORM (__tablename__).
+DATABASES=(
+  "db_auth|db_autenticacao|customuser logs_auditoria"
+  "db_catalogo|db_catalogo|categoria prestador servico horariofuncionamento fotoestabelecimento avaliacao logs_auditoria"
+  "db_agendamentos|db_agendamentos|agendamento historico_agendamento logs_auditoria"
+  "db_notificacoes|db_notificacoes|notificacao logs_auditoria"
+)
+
+DB_USER="${DB_USER:-wonder_user}"
+
+echo "=== Wonder App — Manutenção do PostgreSQL (VACUUM ANALYZE + REINDEX) ==="
+echo "Iniciado em: $(date '+%Y-%m-%d %H:%M:%S')"
+echo
+
+for entry in "${DATABASES[@]}"; do
+  IFS='|' read -r servico banco tabelas <<< "$entry"
+
+  echo "--- Banco: ${banco} (serviço: ${servico}) ---"
+
+  for tabela in $tabelas; do
+    echo "[${banco}] VACUUM ANALYZE ${tabela}..."
+    docker compose exec -T "${servico}" psql -U "${DB_USER}" -d "${banco}" \
+      -c "VACUUM ANALYZE ${tabela};"
+
+    echo "[${banco}] REINDEX TABLE ${tabela}..."
+    docker compose exec -T "${servico}" psql -U "${DB_USER}" -d "${banco}" \
+      -c "REINDEX TABLE ${tabela};"
+  done
+
+  echo "[${banco}] Concluído."
+  echo
+done
+
+echo "=== Manutenção finalizada em: $(date '+%Y-%m-%d %H:%M:%S') ==="


### PR DESCRIPTION
* Criado `scripts/maintenance.sh`, executando VACUUM ANALYZE e REINDEX nas tabelas principais dos quatro bancos (auth, catalogo, agendamentos, notificacoes).
* Criado `scripts/cleanup_logs.sh`, removendo registros de `logs_auditoria` com mais de 90 dias em todos os bancos (dá pra configurar via variável `DIAS_RETENCAO`).
* Ambos os scripts imprimem no terminal qual banco e qual operação estão sendo executados a cada passo.
* Scripts executáveis via `docker compose exec`, sem necessidade de container dedicado.
* Criada documentação em `docs/MANUTENCAO.md`, com descrição de cada script, tabelas cobertas, frequência recomendada e exemplos de uso.
* Testado manualmente nos containers em execução: `maintenance.sh` concluído sem erros nos quatro bancos; `cleanup_logs.sh` retornou `DELETE 0` em todos (esperado, sem logs antigos ainda).