### PR TITLE
Fix/auth google oauth username

### DIFF
--- a/services/auth/src/main/repositories/user_repo.py
+++ b/services/auth/src/main/repositories/user_repo.py
@@ -13,7 +13,10 @@ def upsert_usuario(db: Session, email: str, username: str) -> CustomUser:
     
     stmt = stmt.on_conflict_do_update(
         index_elements=['email'],
-        set_={'atualizado_em': func.now()}
+        set_={
+            'username': stmt.excluded.username,
+            'atualizado_em': func.now()
+        }
     ).returning(CustomUser)
 
     result = db.execute(stmt)

--- a/services/auth/src/main/routes/auth_routes.py
+++ b/services/auth/src/main/routes/auth_routes.py
@@ -104,7 +104,25 @@ async def google_callback(code: str, state: str | None = None, db: Session = Dep
         })
 
         if token_response.status_code != 200:
-            raise HTTPException(status_code=400, detail="Falha ao obter token do Google.")
+            try:
+                google_error = token_response.json()
+            except ValueError:
+                google_error = {}
+
+            print(
+                "[auth][oauth] erro token google:",
+                "status_code=",
+                token_response.status_code,
+                "error=",
+                google_error.get("error"),
+                "error_description=",
+                google_error.get("error_description"),
+                flush=True,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail="Falha na autenticação com Google. Tente novamente.",
+            )
         access_token = token_response.json().get("access_token")
 
         # Busca Usuário

--- a/sql/auth.sql
+++ b/sql/auth.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE IF NOT EXISTS CustomUser (
     id            SERIAL PRIMARY KEY,
-    username      VARCHAR(150) NOT NULL UNIQUE,
+    username      VARCHAR(150) NOT NULL,
     email         VARCHAR(254) NOT NULL UNIQUE,
     tipo_usuario  VARCHAR(20) NOT NULL DEFAULT 'cliente',
     foto_perfil   VARCHAR(500),

--- a/sql/migrations/20260708_auth_drop_unique_username.sql
+++ b/sql/migrations/20260708_auth_drop_unique_username.sql
@@ -1,0 +1,5 @@
+-- Permite que usuarios Google diferentes tenham o mesmo nome de exibicao.
+-- A identidade de login continua sendo o email, que permanece unico.
+
+ALTER TABLE customuser DROP CONSTRAINT IF EXISTS customuser_username_key;
+DROP INDEX IF EXISTS customuser_username_key;


### PR DESCRIPTION
## O que foi implementado

- Adiciona log seguro quando a troca de token do Google falha.
- Remove a unicidade de `customuser.username`.
- Mantém `email` como identidade do usuário.
- Atualiza o upsert para continuar usando `ON CONFLICT(email)`.
- Adiciona migration idempotente para bancos existentes.