### PR TITLE
feat: implementa fluxo prestador no mobile

### DIFF
--- a/wonder-mobile/src/components/ProviderScheduleModal.tsx
+++ b/wonder-mobile/src/components/ProviderScheduleModal.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { theme } from '../styles/theme';
+import { Button } from './Button';
+import { Input } from './Input';
+
+const weekDays = [
+  { label: 'D', value: 0 },
+  { label: 'S', value: 1 },
+  { label: 'T', value: 2 },
+  { label: 'Q', value: 3 },
+  { label: 'Q', value: 4 },
+  { label: 'S', value: 5 },
+  { label: 'S', value: 6 },
+];
+
+type ProviderScheduleModalProps = {
+  visible: boolean;
+  loading?: boolean;
+  onClose: () => void;
+  onSave: (payload: { dia_semana: number; hora_inicio: string; hora_fim: string }) => Promise<void>;
+};
+
+export function ProviderScheduleModal({
+  visible,
+  loading = false,
+  onClose,
+  onSave,
+}: ProviderScheduleModalProps) {
+  const [diaSemana, setDiaSemana] = useState(1);
+  const [horaInicio, setHoraInicio] = useState('08:00');
+  const [horaFim, setHoraFim] = useState('18:00');
+  const [error, setError] = useState('');
+
+  async function handleSave() {
+    if (!/^\d{2}:\d{2}$/.test(horaInicio) || !/^\d{2}:\d{2}$/.test(horaFim)) {
+      setError('Use horarios no formato HH:MM.');
+      return;
+    }
+
+    await onSave({
+      dia_semana: diaSemana,
+      hora_inicio: horaInicio,
+      hora_fim: horaFim,
+    });
+    setError('');
+  }
+
+  return (
+    <Modal transparent animationType="fade" visible={visible} onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <Text style={styles.title}>Selecionar dias e horarios</Text>
+
+          <View style={styles.days}>
+            {weekDays.map((day, index) => {
+              const selected = diaSemana === day.value;
+              return (
+                <Pressable
+                  key={`${day.label}-${index}`}
+                  accessibilityRole="button"
+                  onPress={() => setDiaSemana(day.value)}
+                  style={[styles.dayButton, selected && styles.dayButtonSelected]}
+                >
+                  <Text style={[styles.dayText, selected && styles.dayTextSelected]}>{day.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <View style={styles.row}>
+            <Input label="Horario de inicio" value={horaInicio} onChangeText={setHoraInicio} />
+            <Input label="Horario final" value={horaFim} onChangeText={setHoraFim} />
+          </View>
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <View style={styles.actions}>
+            <Button title="Cancelar" variant="secondary" onPress={onClose} disabled={loading} />
+            <Button title="Salvar" onPress={handleSave} loading={loading} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: theme.spacing.lg,
+  },
+  content: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    gap: theme.spacing.md,
+    maxWidth: 420,
+    padding: theme.spacing.lg,
+    width: '100%',
+  },
+  title: {
+    color: theme.colors.text,
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.bold,
+    textAlign: 'center',
+  },
+  days: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  dayButton: {
+    alignItems: 'center',
+    borderColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.pill,
+    borderWidth: 1,
+    height: 32,
+    justifyContent: 'center',
+    width: 32,
+  },
+  dayButtonSelected: {
+    backgroundColor: theme.colors.primary,
+  },
+  dayText: {
+    color: theme.colors.primary,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.bold,
+  },
+  dayTextSelected: {
+    color: theme.colors.white,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  error: {
+    color: theme.colors.error,
+    fontSize: theme.fontSize.sm,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    justifyContent: 'flex-end',
+  },
+});

--- a/wonder-mobile/src/components/ProviderServiceModal.tsx
+++ b/wonder-mobile/src/components/ProviderServiceModal.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { Modal, StyleSheet, Text, View } from 'react-native';
+
+import { theme } from '../styles/theme';
+import { Button } from './Button';
+import { Input } from './Input';
+
+type ProviderServiceModalProps = {
+  visible: boolean;
+  loading?: boolean;
+  onClose: () => void;
+  onSave: (payload: { nome: string; preco: number; duracao_min: number }) => Promise<void>;
+};
+
+export function ProviderServiceModal({
+  visible,
+  loading = false,
+  onClose,
+  onSave,
+}: ProviderServiceModalProps) {
+  const [nome, setNome] = useState('');
+  const [preco, setPreco] = useState('');
+  const [duracao, setDuracao] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSave() {
+    const precoNumber = Number(preco.replace(',', '.'));
+    const duracaoNumber = Number(duracao);
+
+    if (!nome.trim() || Number.isNaN(precoNumber) || Number.isNaN(duracaoNumber)) {
+      setError('Preencha nome, preco e duracao.');
+      return;
+    }
+
+    await onSave({
+      nome: nome.trim(),
+      preco: precoNumber,
+      duracao_min: duracaoNumber,
+    });
+    setNome('');
+    setPreco('');
+    setDuracao('');
+    setError('');
+  }
+
+  return (
+    <Modal transparent animationType="fade" visible={visible} onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <Text style={styles.title}>Cadastro de servico</Text>
+
+          <Input label="Nome do servico" placeholder="Corte degradado" value={nome} onChangeText={setNome} />
+          <Input
+            label="Preco"
+            keyboardType="decimal-pad"
+            placeholder="45.00"
+            value={preco}
+            onChangeText={setPreco}
+          />
+          <Input
+            label="Duracao em minutos"
+            keyboardType="number-pad"
+            placeholder="30"
+            value={duracao}
+            onChangeText={setDuracao}
+          />
+
+          <View style={styles.imagePlaceholder}>
+            <Text style={styles.imageText}>Imagem opcional fora do escopo</Text>
+          </View>
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <View style={styles.actions}>
+            <Button title="Cancelar" variant="secondary" onPress={onClose} disabled={loading} />
+            <Button title="Salvar" onPress={handleSave} loading={loading} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: theme.spacing.lg,
+  },
+  content: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    gap: theme.spacing.md,
+    maxWidth: 420,
+    padding: theme.spacing.lg,
+    width: '100%',
+  },
+  title: {
+    color: theme.colors.text,
+    fontSize: theme.fontSize.xl,
+    fontWeight: theme.fontWeight.bold,
+    textAlign: 'center',
+    textTransform: 'uppercase',
+  },
+  imagePlaceholder: {
+    alignItems: 'center',
+    borderColor: theme.colors.textMuted,
+    borderRadius: theme.borderRadius.sm,
+    borderStyle: 'dashed',
+    borderWidth: 1,
+    height: 96,
+    justifyContent: 'center',
+  },
+  imageText: {
+    color: theme.colors.textMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  error: {
+    color: theme.colors.error,
+    fontSize: theme.fontSize.sm,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    justifyContent: 'flex-end',
+  },
+});

--- a/wonder-mobile/src/navigation/MainTabs.tsx
+++ b/wonder-mobile/src/navigation/MainTabs.tsx
@@ -1,9 +1,12 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Text } from 'react-native';
 
+import { useAuth } from '../contexts/AuthContext';
 import { AppointmentsScreen } from '../screens/AppointmentsScreen';
 import { HomeScreen } from '../screens/HomeScreen';
 import { ProfileScreen } from '../screens/ProfileScreen';
+import { ProviderAgendaScreen } from '../screens/ProviderAgendaScreen';
+import { ProviderProfileScreen } from '../screens/ProviderProfileScreen';
 import { SearchScreen } from '../screens/SearchScreen';
 import { theme } from '../styles/theme';
 
@@ -14,83 +17,129 @@ export type MainTabsParamList = {
   Profile: undefined;
 };
 
-const Tab = createBottomTabNavigator<MainTabsParamList>();
-
-const tabIcons: Record<keyof MainTabsParamList, string> = {
-  Home: '⌂',
-  Search: '⌕',
-  Appointments: '◷',
-  Profile: '●',
+type ProviderTabsParamList = {
+  ProviderAgenda: undefined;
+  ProviderProfile: undefined;
 };
 
+const ClientTab = createBottomTabNavigator<MainTabsParamList>();
+const ProviderTab = createBottomTabNavigator<ProviderTabsParamList>();
+
+const clientTabIcons: Record<keyof MainTabsParamList, string> = {
+  Home: 'H',
+  Search: 'B',
+  Appointments: 'A',
+  Profile: 'P',
+};
+
+const providerTabIcons: Record<keyof ProviderTabsParamList, string> = {
+  ProviderAgenda: 'A',
+  ProviderProfile: 'P',
+};
+
+const sharedScreenOptions = {
+  headerShown: false,
+  tabBarActiveTintColor: theme.colors.primary,
+  tabBarInactiveTintColor: theme.colors.textMuted,
+  tabBarLabelStyle: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.semibold,
+  },
+  tabBarStyle: {
+    backgroundColor: theme.colors.surface,
+    borderTopColor: theme.colors.border,
+    height: 64,
+    paddingBottom: theme.spacing.sm,
+    paddingTop: theme.spacing.xs,
+  },
+} as const;
+
 export function MainTabs() {
+  const { usuario } = useAuth();
+  const tipoUsuario = usuario?.tipo_usuario?.toLowerCase();
+  const useProviderFlow = tipoUsuario === 'prestador';
+
+  if (useProviderFlow) {
+    return (
+      <ProviderTab.Navigator screenOptions={sharedScreenOptions}>
+        <ProviderTab.Screen
+          name="ProviderAgenda"
+          component={ProviderAgendaScreen}
+          options={{
+            title: 'Agendamentos',
+            tabBarIcon: ({ color, size }) => (
+              <Text style={{ color, fontSize: size, fontWeight: theme.fontWeight.bold }}>
+                {providerTabIcons.ProviderAgenda}
+              </Text>
+            ),
+          }}
+        />
+        <ProviderTab.Screen
+          name="ProviderProfile"
+          component={ProviderProfileScreen}
+          options={{
+            title: 'Perfil',
+            tabBarIcon: ({ color, size }) => (
+              <Text style={{ color, fontSize: size, fontWeight: theme.fontWeight.bold }}>
+                {providerTabIcons.ProviderProfile}
+              </Text>
+            ),
+          }}
+        />
+      </ProviderTab.Navigator>
+    );
+  }
+
   return (
-    <Tab.Navigator
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: theme.colors.primary,
-        tabBarInactiveTintColor: theme.colors.textMuted,
-        tabBarLabelStyle: {
-          fontSize: theme.fontSize.xs,
-          fontWeight: theme.fontWeight.semibold,
-        },
-        tabBarStyle: {
-          backgroundColor: theme.colors.surface,
-          borderTopColor: theme.colors.border,
-          height: 64,
-          paddingBottom: theme.spacing.sm,
-          paddingTop: theme.spacing.xs,
-        },
-      }}
-    >
-      <Tab.Screen
+    <ClientTab.Navigator screenOptions={sharedScreenOptions}>
+      <ClientTab.Screen
         name="Home"
         component={HomeScreen}
         options={{
-          title: 'Início',
+          title: 'Inicio',
           tabBarIcon: ({ color, size }) => (
             <Text style={{ color, fontSize: size, fontWeight: theme.fontWeight.bold }}>
-              {tabIcons.Home}
+              {clientTabIcons.Home}
             </Text>
           ),
         }}
       />
-      <Tab.Screen
+      <ClientTab.Screen
         name="Search"
         component={SearchScreen}
         options={{
           title: 'Buscar',
           tabBarIcon: ({ color, size }) => (
             <Text style={{ color, fontSize: size, fontWeight: theme.fontWeight.bold }}>
-              {tabIcons.Search}
+              {clientTabIcons.Search}
             </Text>
           ),
         }}
       />
-      <Tab.Screen
+      <ClientTab.Screen
         name="Appointments"
         component={AppointmentsScreen}
         options={{
           title: 'Agenda',
           tabBarIcon: ({ color, size }) => (
             <Text style={{ color, fontSize: size, fontWeight: theme.fontWeight.bold }}>
-              {tabIcons.Appointments}
+              {clientTabIcons.Appointments}
             </Text>
           ),
         }}
       />
-      <Tab.Screen
+      <ClientTab.Screen
         name="Profile"
         component={ProfileScreen}
         options={{
           title: 'Perfil',
           tabBarIcon: ({ color, size }) => (
             <Text style={{ color, fontSize: size, fontWeight: theme.fontWeight.bold }}>
-              {tabIcons.Profile}
+              {clientTabIcons.Profile}
             </Text>
           ),
         }}
       />
-    </Tab.Navigator>
+    </ClientTab.Navigator>
   );
 }

--- a/wonder-mobile/src/screens/ProviderAgendaScreen.tsx
+++ b/wonder-mobile/src/screens/ProviderAgendaScreen.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { Button } from '../components/Button';
+import { Card } from '../components/Card';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { useAuth } from '../contexts/AuthContext';
+import {
+  atualizarStatusAgendamento,
+  listarAgendamentos,
+  listarServicos,
+  obterPrestadorLogado,
+} from '../services/provider';
+import { theme } from '../styles/theme';
+import { Agendamento, Prestador, Servico } from '../types/provider';
+
+type AgendaTab = 'abertos' | 'finalizados';
+
+const openStatuses = ['pendente', 'confirmado'];
+const doneStatuses = ['concluido', 'finalizado'];
+
+export function ProviderAgendaScreen() {
+  const { usuario, signOut } = useAuth();
+  const [prestador, setPrestador] = useState<Prestador | null>(null);
+  const [agendamentos, setAgendamentos] = useState<Agendamento[]>([]);
+  const [servicos, setServicos] = useState<Servico[]>([]);
+  const [activeTab, setActiveTab] = useState<AgendaTab>('abertos');
+  const [showCanceled, setShowCanceled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [savingId, setSavingId] = useState<number | null>(null);
+  const [error, setError] = useState('');
+
+  const servicosById = useMemo(() => {
+    return servicos.reduce<Record<number, Servico>>((acc, servico) => {
+      acc[servico.id] = servico;
+      return acc;
+    }, {});
+  }, [servicos]);
+
+  const visibleAppointments = useMemo(() => {
+    if (activeTab === 'abertos') {
+      return agendamentos.filter((agendamento) => openStatuses.includes(agendamento.status));
+    }
+
+    if (showCanceled) {
+      return agendamentos.filter((agendamento) => agendamento.status === 'cancelado');
+    }
+
+    return agendamentos.filter((agendamento) => doneStatuses.includes(agendamento.status));
+  }, [activeTab, agendamentos, showCanceled]);
+
+  const loadAgenda = useCallback(async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const nextAgendamentos = await listarAgendamentos();
+      setAgendamentos(nextAgendamentos);
+
+      if (usuario?.id) {
+        const foundPrestador = await obterPrestadorLogado(usuario.id);
+        setPrestador(foundPrestador);
+        if (foundPrestador) {
+          setServicos(await listarServicos(foundPrestador.id));
+        }
+      }
+    } catch {
+      setError('Nao foi possivel carregar os agendamentos.');
+    } finally {
+      setLoading(false);
+    }
+  }, [usuario?.id]);
+
+  useEffect(() => {
+    loadAgenda();
+  }, [loadAgenda]);
+
+  async function handleStatus(agendamentoId: number, status: string) {
+    setSavingId(agendamentoId);
+    setError('');
+    try {
+      await atualizarStatusAgendamento(agendamentoId, status);
+      setAgendamentos(await listarAgendamentos());
+    } catch {
+      setError('Nao foi possivel atualizar o agendamento.');
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  if (loading) {
+    return <LoadingIndicator text="Carregando agendamentos..." />;
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.container}
+      refreshControl={<RefreshControl refreshing={loading} onRefresh={loadAgenda} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.greeting}>Ola, {prestador?.nome_estab || usuario?.email || 'prestador'}</Text>
+        <Button title="Sair" size="sm" variant="secondary" onPress={signOut} />
+      </View>
+
+      <View style={styles.segment}>
+        <Button
+          title="Em aberto"
+          variant={activeTab === 'abertos' ? 'primary' : 'outline'}
+          onPress={() => setActiveTab('abertos')}
+          style={styles.segmentButton}
+        />
+        <Button
+          title="Finalizados"
+          variant={activeTab === 'finalizados' ? 'primary' : 'outline'}
+          onPress={() => setActiveTab('finalizados')}
+          style={styles.segmentButton}
+        />
+      </View>
+
+      {activeTab === 'finalizados' ? (
+        <View style={styles.filterRow}>
+          <Text style={styles.dateBadge}>{new Date().toLocaleDateString('pt-BR')}</Text>
+          <Button
+            title={showCanceled ? 'Ver concluidos' : 'Ver cancelados'}
+            size="sm"
+            variant={showCanceled ? 'primary' : 'outline'}
+            onPress={() => setShowCanceled((current) => !current)}
+          />
+        </View>
+      ) : (
+        <Text style={styles.sectionTitle}>Agendado hoje</Text>
+      )}
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      {visibleAppointments.length ? (
+        visibleAppointments.map((agendamento) => (
+          <AppointmentCard
+            key={agendamento.id}
+            agendamento={agendamento}
+            servico={servicosById[agendamento.servico_id]}
+            saving={savingId === agendamento.id}
+            showActions={activeTab === 'abertos'}
+            onFinish={() => handleStatus(agendamento.id, 'concluido')}
+            onCancel={() => handleStatus(agendamento.id, 'cancelado')}
+          />
+        ))
+      ) : (
+        <Card>
+          <Text style={styles.emptyText}>Nenhum agendamento para este filtro.</Text>
+        </Card>
+      )}
+    </ScrollView>
+  );
+}
+
+function AppointmentCard({
+  agendamento,
+  servico,
+  saving,
+  showActions,
+  onFinish,
+  onCancel,
+}: {
+  agendamento: Agendamento;
+  servico?: Servico;
+  saving: boolean;
+  showActions: boolean;
+  onFinish: () => void;
+  onCancel: () => void;
+}) {
+  const start = new Date(agendamento.inicio);
+  const dateLabel = Number.isNaN(start.getTime())
+    ? agendamento.inicio
+    : `${start.toLocaleDateString('pt-BR')} ${start.toLocaleTimeString('pt-BR', {
+        hour: '2-digit',
+        minute: '2-digit',
+      })}`;
+
+  return (
+    <Card style={styles.appointmentCard}>
+      <View style={styles.appointmentAvatar}>
+        <Text style={styles.appointmentAvatarText}>#{agendamento.cliente_id}</Text>
+      </View>
+      <View style={styles.appointmentInfo}>
+        <Text style={styles.cardTitle}>{servico?.nome || `Servico ${agendamento.servico_id}`}</Text>
+        <Text style={styles.cardText}>Cliente {agendamento.cliente_id}</Text>
+        <Text style={styles.cardText}>{dateLabel}</Text>
+      </View>
+      {showActions ? (
+        <View style={styles.actions}>
+          <Button title="Finalizar" size="sm" variant="outline" loading={saving} onPress={onFinish} />
+          <Button title="Cancelar" size="sm" variant="danger" disabled={saving} onPress={onCancel} />
+        </View>
+      ) : (
+        <Text style={[styles.statusBadge, agendamento.status === 'cancelado' && styles.statusCanceled]}>
+          {agendamento.status}
+        </Text>
+      )}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: theme.colors.background,
+    gap: theme.spacing.md,
+    padding: theme.spacing.lg,
+    paddingBottom: theme.spacing.xxl,
+    paddingTop: theme.spacing.xxl,
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  greeting: {
+    color: theme.colors.primary,
+    flex: 1,
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.bold,
+  },
+  segment: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  segmentButton: {
+    flex: 1,
+  },
+  filterRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  dateBadge: {
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.sm,
+    color: theme.colors.white,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.bold,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xs,
+  },
+  sectionTitle: {
+    color: theme.colors.primary,
+    fontSize: theme.fontSize.md,
+    fontWeight: theme.fontWeight.bold,
+    textTransform: 'uppercase',
+  },
+  appointmentCard: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  appointmentAvatar: {
+    alignItems: 'center',
+    backgroundColor: theme.colors.surfaceMuted,
+    borderRadius: theme.borderRadius.md,
+    height: 56,
+    justifyContent: 'center',
+    width: 56,
+  },
+  appointmentAvatarText: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.bold,
+  },
+  appointmentInfo: {
+    flex: 1,
+    gap: theme.spacing.xs,
+  },
+  cardTitle: {
+    color: theme.colors.text,
+    fontSize: theme.fontSize.md,
+    fontWeight: theme.fontWeight.bold,
+  },
+  cardText: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.sm,
+  },
+  actions: {
+    gap: theme.spacing.xs,
+    width: 96,
+  },
+  statusBadge: {
+    backgroundColor: theme.colors.success,
+    borderRadius: theme.borderRadius.sm,
+    color: theme.colors.white,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.bold,
+    overflow: 'hidden',
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xs,
+    textTransform: 'uppercase',
+  },
+  statusCanceled: {
+    backgroundColor: theme.colors.error,
+  },
+  emptyText: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.md,
+    textAlign: 'center',
+  },
+  error: {
+    color: theme.colors.error,
+    fontSize: theme.fontSize.sm,
+  },
+});

--- a/wonder-mobile/src/screens/ProviderProfileScreen.tsx
+++ b/wonder-mobile/src/screens/ProviderProfileScreen.tsx
@@ -1,0 +1,374 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { Button } from '../components/Button';
+import { Card } from '../components/Card';
+import { Input } from '../components/Input';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { ProviderScheduleModal } from '../components/ProviderScheduleModal';
+import { ProviderServiceModal } from '../components/ProviderServiceModal';
+import { useAuth } from '../contexts/AuthContext';
+import {
+  criarHorario,
+  criarPrestador,
+  criarServico,
+  listarHorarios,
+  listarServicos,
+  obterPrestadorLogado,
+  removerHorario,
+} from '../services/provider';
+import { theme } from '../styles/theme';
+import { Horario, Prestador, Servico } from '../types/provider';
+
+const dayLabels = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab'];
+
+export function ProviderProfileScreen() {
+  const { usuario, signOut } = useAuth();
+  const [prestador, setPrestador] = useState<Prestador | null>(null);
+  const [servicos, setServicos] = useState<Servico[]>([]);
+  const [horarios, setHorarios] = useState<Horario[]>([]);
+  const [nomeEstab, setNomeEstab] = useState('');
+  const [documento, setDocumento] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [serviceModalVisible, setServiceModalVisible] = useState(false);
+  const [scheduleModalVisible, setScheduleModalVisible] = useState(false);
+
+  const horariosResumo = useMemo(() => {
+    if (!horarios.length) {
+      return 'Nenhum horario cadastrado';
+    }
+
+    return horarios
+      .map((horario) => `${dayLabels[horario.dia_semana] || 'Dia'} ${horario.hora_inicio} - ${horario.hora_fim}`)
+      .join(', ');
+  }, [horarios]);
+
+  const loadProfile = useCallback(async () => {
+    if (!usuario?.id) {
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+    try {
+      const foundPrestador = await obterPrestadorLogado(usuario.id);
+      setPrestador(foundPrestador);
+      setNomeEstab(foundPrestador?.nome_estab || '');
+      setDocumento(foundPrestador?.documento || '');
+
+      if (foundPrestador) {
+        const [nextServicos, nextHorarios] = await Promise.all([
+          listarServicos(foundPrestador.id),
+          listarHorarios(foundPrestador.id),
+        ]);
+        setServicos(nextServicos);
+        setHorarios(nextHorarios);
+      } else {
+        setServicos([]);
+        setHorarios([]);
+      }
+    } catch {
+      setError('Nao foi possivel carregar o perfil do prestador.');
+    } finally {
+      setLoading(false);
+    }
+  }, [usuario?.id]);
+
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
+
+  async function handleCreatePrestador() {
+    if (!nomeEstab.trim() || !documento.trim()) {
+      setError('Informe nome do estabelecimento e documento.');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      const created = await criarPrestador({
+        nome_estab: nomeEstab.trim(),
+        documento: documento.trim(),
+      });
+      setPrestador(created);
+      await loadProfile();
+    } catch {
+      setError('Nao foi possivel criar o perfil do prestador.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleCreateService(payload: { nome: string; preco: number; duracao_min: number }) {
+    if (!prestador) {
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      await criarServico(prestador.id, payload);
+      setServiceModalVisible(false);
+      setServicos(await listarServicos(prestador.id));
+    } catch {
+      setError('Nao foi possivel cadastrar o servico.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleCreateSchedule(payload: { dia_semana: number; hora_inicio: string; hora_fim: string }) {
+    if (!prestador) {
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      await criarHorario(prestador.id, payload);
+      setScheduleModalVisible(false);
+      setHorarios(await listarHorarios(prestador.id));
+    } catch {
+      setError('Nao foi possivel cadastrar o horario.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRemoveSchedule(horarioId: number) {
+    if (!prestador) {
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      await removerHorario(prestador.id, horarioId);
+      setHorarios(await listarHorarios(prestador.id));
+    } catch {
+      setError('Nao foi possivel remover o horario.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <LoadingIndicator text="Carregando perfil..." />;
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.container}
+      refreshControl={<RefreshControl refreshing={loading} onRefresh={loadProfile} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.greeting}>Ola, {prestador?.nome_estab || usuario?.email || 'prestador'}</Text>
+        <Button title="Sair" size="sm" variant="secondary" onPress={signOut} />
+      </View>
+
+      {!prestador ? (
+        <Card style={styles.formCard}>
+          <Text style={styles.title}>Criar perfil de prestador</Text>
+          <Input
+            label="Nome do estabelecimento"
+            placeholder="Diego BarberShop"
+            value={nomeEstab}
+            onChangeText={setNomeEstab}
+          />
+          <Input label="CPF/CNPJ" placeholder="00.000.000/0000-00" value={documento} onChangeText={setDocumento} />
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+          <Button title="Salvar perfil" onPress={handleCreatePrestador} loading={saving} />
+        </Card>
+      ) : (
+        <>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarText}>{prestador.nome_estab.slice(0, 1).toUpperCase()}</Text>
+          </View>
+
+          <Card style={styles.metricsCard}>
+            <Text style={styles.metricText}>Avaliacao: -</Text>
+            <Text style={styles.metricText}>Servicos: {servicos.length}</Text>
+          </Card>
+
+          <Card style={styles.detailsCard}>
+            <InfoRow label="Nome do estabelecimento" value={prestador.nome_estab} />
+            <InfoRow label="CPF/CNPJ" value={prestador.documento} />
+            <InfoRow label="Email" value={usuario?.email || '-'} />
+            <InfoRow label="Horario de funcionamento" value={horariosResumo} />
+          </Card>
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Horarios cadastrados</Text>
+            <Button title="Adicionar" size="sm" onPress={() => setScheduleModalVisible(true)} />
+          </View>
+
+          {horarios.map((horario) => (
+            <Card key={horario.id} style={styles.listCard}>
+              <View style={styles.listRow}>
+                <Text style={styles.cardTitle}>{dayLabels[horario.dia_semana] || 'Dia'}</Text>
+                <Text style={styles.cardText}>
+                  {horario.hora_inicio} - {horario.hora_fim}
+                </Text>
+                <Button
+                  title="Remover"
+                  size="sm"
+                  variant="outline"
+                  onPress={() => handleRemoveSchedule(horario.id)}
+                  disabled={saving}
+                />
+              </View>
+            </Card>
+          ))}
+
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Servicos cadastrados</Text>
+            <Button title="Cadastrar" size="sm" onPress={() => setServiceModalVisible(true)} />
+          </View>
+
+          {servicos.map((servico) => (
+            <Card key={servico.id} style={styles.listCard}>
+              <Text style={styles.cardTitle}>{servico.nome}</Text>
+              <Text style={styles.cardText}>
+                R$ {servico.preco.toFixed(2)} - {servico.duracao_min} min
+              </Text>
+            </Card>
+          ))}
+        </>
+      )}
+
+      <ProviderServiceModal
+        visible={serviceModalVisible}
+        loading={saving}
+        onClose={() => setServiceModalVisible(false)}
+        onSave={handleCreateService}
+      />
+      <ProviderScheduleModal
+        visible={scheduleModalVisible}
+        loading={saving}
+        onClose={() => setScheduleModalVisible(false)}
+        onSave={handleCreateSchedule}
+      />
+    </ScrollView>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.infoRow}>
+      <Text style={styles.infoLabel}>{label}</Text>
+      <Text style={styles.infoValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: theme.colors.background,
+    gap: theme.spacing.md,
+    padding: theme.spacing.lg,
+    paddingBottom: theme.spacing.xxl,
+    paddingTop: theme.spacing.xxl,
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  greeting: {
+    color: theme.colors.primary,
+    flex: 1,
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.bold,
+  },
+  title: {
+    color: theme.colors.text,
+    fontSize: theme.fontSize.xl,
+    fontWeight: theme.fontWeight.bold,
+  },
+  formCard: {
+    gap: theme.spacing.md,
+  },
+  avatar: {
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: theme.colors.surfaceMuted,
+    borderColor: theme.colors.primary,
+    borderRadius: 74,
+    borderWidth: 2,
+    height: 148,
+    justifyContent: 'center',
+    width: 148,
+  },
+  avatarText: {
+    color: theme.colors.primary,
+    fontSize: 56,
+    fontWeight: theme.fontWeight.bold,
+  },
+  metricsCard: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  metricText: {
+    color: theme.colors.text,
+    fontSize: theme.fontSize.md,
+    fontWeight: theme.fontWeight.semibold,
+  },
+  detailsCard: {
+    gap: theme.spacing.sm,
+  },
+  infoRow: {
+    backgroundColor: theme.colors.surfaceMuted,
+    borderRadius: theme.borderRadius.sm,
+    gap: theme.spacing.xs,
+    padding: theme.spacing.sm,
+  },
+  infoLabel: {
+    color: theme.colors.text,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.bold,
+  },
+  infoValue: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.sm,
+  },
+  sectionHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    color: theme.colors.text,
+    flex: 1,
+    fontSize: theme.fontSize.md,
+    fontWeight: theme.fontWeight.bold,
+  },
+  listCard: {
+    gap: theme.spacing.xs,
+  },
+  listRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    justifyContent: 'space-between',
+  },
+  cardTitle: {
+    color: theme.colors.text,
+    flex: 1,
+    fontSize: theme.fontSize.md,
+    fontWeight: theme.fontWeight.bold,
+  },
+  cardText: {
+    color: theme.colors.textSecondary,
+    flex: 1,
+    fontSize: theme.fontSize.sm,
+  },
+  error: {
+    color: theme.colors.error,
+    fontSize: theme.fontSize.sm,
+  },
+});

--- a/wonder-mobile/src/services/provider.ts
+++ b/wonder-mobile/src/services/provider.ts
@@ -1,0 +1,67 @@
+import api from './api';
+import {
+  Agendamento,
+  Horario,
+  HorarioPayload,
+  Prestador,
+  PrestadorPayload,
+  Servico,
+  ServicoPayload,
+} from '../types/provider';
+
+export async function listarPrestadores() {
+  const response = await api.get<Prestador[]>('/catalogo/prestadores');
+  return response.data;
+}
+
+export async function obterPrestadorLogado(usuarioId: string | number) {
+  const prestadores = await listarPrestadores();
+  return prestadores.find((prestador) => String(prestador.usuario_id) === String(usuarioId)) || null;
+}
+
+export async function criarPrestador(payload: PrestadorPayload) {
+  const response = await api.post<Prestador>('/catalogo/prestadores', payload);
+  return response.data;
+}
+
+export async function atualizarPrestador(prestadorId: number, payload: Partial<PrestadorPayload>) {
+  const response = await api.put<Prestador>(`/catalogo/prestadores/${prestadorId}`, payload);
+  return response.data;
+}
+
+export async function listarServicos(prestadorId: number) {
+  const response = await api.get<Servico[]>(`/catalogo/prestadores/${prestadorId}/servicos`);
+  return response.data;
+}
+
+export async function criarServico(prestadorId: number, payload: ServicoPayload) {
+  const response = await api.post<Servico>(`/catalogo/prestadores/${prestadorId}/servicos`, payload);
+  return response.data;
+}
+
+export async function listarHorarios(prestadorId: number) {
+  const response = await api.get<Horario[]>(`/catalogo/prestadores/${prestadorId}/horarios`);
+  return response.data;
+}
+
+export async function criarHorario(prestadorId: number, payload: HorarioPayload) {
+  const response = await api.post<Horario>(`/catalogo/prestadores/${prestadorId}/horarios`, payload);
+  return response.data;
+}
+
+export async function removerHorario(prestadorId: number, horarioId: number) {
+  await api.delete(`/catalogo/prestadores/${prestadorId}/horarios/${horarioId}`);
+}
+
+export async function listarAgendamentos() {
+  const response = await api.get<Agendamento[]>('/agendamentos');
+  return response.data;
+}
+
+export async function atualizarStatusAgendamento(agendamentoId: number, status: string, motivo?: string) {
+  const response = await api.patch<Agendamento>(`/agendamentos/${agendamentoId}/status`, {
+    status,
+    motivo,
+  });
+  return response.data;
+}

--- a/wonder-mobile/src/types/provider.ts
+++ b/wonder-mobile/src/types/provider.ts
@@ -1,0 +1,51 @@
+export type Prestador = {
+  id: number;
+  usuario_id: string | number;
+  nome_estab: string;
+  documento: string;
+  status: string;
+};
+
+export type Servico = {
+  id: number;
+  prestador_id: number;
+  nome: string;
+  preco: number;
+  duracao_min: number;
+  categoria_id?: number | null;
+};
+
+export type Horario = {
+  id: number;
+  prestador_id: number;
+  dia_semana: number;
+  hora_inicio: string;
+  hora_fim: string;
+};
+
+export type Agendamento = {
+  id: number;
+  cliente_id: number;
+  prestador_id: number;
+  servico_id: number;
+  inicio: string;
+  status: string;
+};
+
+export type PrestadorPayload = {
+  nome_estab: string;
+  documento: string;
+};
+
+export type ServicoPayload = {
+  nome: string;
+  preco: number;
+  duracao_min: number;
+  categoria_id?: number;
+};
+
+export type HorarioPayload = {
+  dia_semana: number;
+  hora_inicio: string;
+  hora_fim: string;
+};


### PR DESCRIPTION
Issue 37

## O que foi implementado

- Adiciona fluxo específico para usuário `prestador`.
- Cria tela de agenda do prestador.
- Cria tela de perfil do prestador.
- Permite criar perfil em `POST /catalogo/prestadores`.
- Permite cadastrar serviços.
- Permite cadastrar e remover horários.
- Usa `api.ts` para chamadas autenticadas.
- Usa `useAuth()` para exibir fluxo apenas quando `tipo_usuario == "prestador"`.